### PR TITLE
Make cards flat with option for extra info

### DIFF
--- a/_includes/people_card.html
+++ b/_includes/people_card.html
@@ -1,0 +1,40 @@
+<!-- _includes/projects.html -->
+<div class="grid-sizer"></div>
+<div class="grid-item">
+  
+  <div class="card">
+    {%- if project.img %}
+   
+    {%- include figure.html
+      path=project.img
+      alt="project thumbnail"
+      class="img-fluid circular z-depth-1 centered-image" -%}
+   
+    {%- endif %}
+    <div class="card-body">
+      <h6 class="card-title">{{ project.title }}</h6>
+      <!-- <em class="card-title">{{ project.title2 }}</em> -->
+      <em class="card-text">{{ project.description }}</em>
+      {% if project.extra_info %}
+      <div class="extra-info">
+        {{ project.extra_info }}
+      </div>
+      {% endif %}
+      <div class="row ml-1 mr-1 p-0">
+        {%- if project.github -%}
+        <div class="github-icon">
+          <div class="icon" data-toggle="tooltip" title="Code Repository">
+            <a href="{{ project.github }}"><i class="fab fa-github gh-icon"></i></a>
+          </div>
+          {%- if project.github_stars -%}
+          <span class="stars" data-toggle="tooltip" title="GitHub Stars">
+            <i class="fas fa-star"></i>
+            <span id="{{ project.github_stars }}-stars"></span>
+          </span>
+          {%- endif %}
+        </div>
+        {%- endif %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/people_horizontal.html
+++ b/_includes/people_horizontal.html
@@ -1,0 +1,50 @@
+<div class="card-item col">
+
+  <div class="card">
+    <div class="row g-0">
+
+      {%- if project.img -%}
+      <div class="card-img col-md-3">
+        {% include figure.html path=project.img alt="project thumbnail" style="margin-left: 5px" %}
+      </div>
+      <div class="col-md-9">
+      {%- else -%}
+      <div class="col-md-12">
+      {%- endif -%}
+
+        <div class="card-body">
+          <h5 class="card-title2">{{ project.title }}</h5>
+          <em class="card-title2">{{ project.title2 }}</em>
+          <p class="card-text text-left">{{ project.description }}</p>
+            {% if project.extra_info %}
+            <div class="extra-info">
+              {{ project.extra_info }}
+            </div>
+            {% endif %}
+          <div class="row ml-1 mr-1 p-0">
+            {%- if project.github -%}
+            <div class="github-icon">
+              <div class="icon" data-toggle="tooltip" title="Code Repository">
+                <a href="{{ project.github }}">
+                  <i class="fab fa-github gh-icon"></i>
+                </a>
+              </div>
+
+              {%- if project.github_stars -%}
+              <span class="stars" data-toggle="tooltip" title="GitHub Stars">
+                <i class="fas fa-star"></i>
+                <span id="{{ project.github_stars }}-stars"></span>
+              </span>
+              {%- endif -%}
+
+            </div>
+            {%- endif -%}
+          </div>
+
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</div>

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -25,7 +25,7 @@ title_ignore: true
   <div class="container">
     <div class="row row-cols-1">
     {%- for project in sorted_projects -%}
-      {% include projects_horizontal.html %}
+      {% include people_horizontal.html %}
     {%- endfor %}
     </div>
   </div>
@@ -45,14 +45,14 @@ title_ignore: true
   <div class="container">
     <div class="row row-cols-1">
     {%- for project in sorted_projects -%}
-      {% include projects_horizontal.html %}
+      {% include people_horizontal.html %}
     {%- endfor %}
     </div>
   </div>
   {%- else -%}
   <div class="grid">
     {%- for project in sorted_projects -%}
-      {% include projects.html %}
+      {% include people_card.html %} <!--UPDATED: projects.html to people_card.html-->
     {%- endfor %}
   </div>
   {%- endif -%}

--- a/_projects/1_JiefengSun.md
+++ b/_projects/1_JiefengSun.md
@@ -2,11 +2,15 @@
 layout: page
 title: Jiefeng Sun, PhD
 title2: Assistant Professor in Robotics
-description: Jiefeng Sun is an assistant professor in Mechanical Engineering at Arizona State University. His research focused on the design and modeling of artificial-muscle-driven robots that match the adaptivity of natural organisms. His work has been selected as the finalist for the best student paper award at the 2018 IEEE IROS. He is the Reviewer of the Year 2021 for Smart Materials and Structures Journal. He was also selected as a 2022 DARPA Riser. Before ASU, he was a postdoc at Yale University after he obtained his Ph.D. degree in mechanical engineering from Colorado State University. 
-
+description: Jiefeng Sun is an assistant professor in Mechanical Engineering at Arizona State University. His research focused on the design and modeling of artificial-muscle-driven robots that match the adaptivity of natural organisms. His work has been selected as the finalist for the best student paper award at the 2018 IEEE IROS. He is the Reviewer of the Year 2021 for Smart Materials and Structures Journal. He was also selected as a 2022 DARPA Riser. Before ASU, he was a postdoc at Yale University after he obtained his Ph.D. degree in mechanical engineering from Colorado State University.
+#extra_info: >
+#  <ul>
+#  <li><a href="https://jiefengsun.github.io/">Personal Website</a></li>
+#  <li>info 2</li>
+#  </ul>
 img: assets/img/headshots/Jiefeng_Sun.jpg
 importance: 1
 redirect: https://jiefengsun.github.io/
-inline: ture # to turn on/off the url
+inline: true # to turn on/off the url
 category: Faculty
 ---

--- a/_projects/2_Jiahe_Wang.md
+++ b/_projects/2_Jiahe_Wang.md
@@ -1,8 +1,13 @@
 ---
 layout: page
 title: Jiahe Wang
-title2:  
+title2: 
 description: PhD student, ME, F24
+#extra_info: >
+#  <ul>
+#  <li>Info 1</li>
+#  <li>Info 2</li>
+#  </ul>
 img: assets/img/headshots/Jiahe_Wang.jpg
 importance: 3
 category: Graduate Students

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -111,6 +111,25 @@ slid_img {
     text-align: center;
   }
 
+  /* UPDATED for extra-info */
+  .extra-info {
+    font-style: normal;       
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+    text-align: left;
+    color: var(--global-text-color); 
+  }
+
+  .extra-info a {
+    color: var(--global-theme-color);
+    text-decoration: underline;
+
+    &:hover {
+      color: var(--global-hover-color);
+    }
+  }
+  /* UPDATED */
+
   .text-left {
     text-align: left !important; /* Overrides center alignment */
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+#version: "3"
 # this file uses prebuilt image in dockerhub
 services:
   jekyll:


### PR DESCRIPTION
## Pull Request: Make cards flat with extra_info field for People page

### What changed

* docker-compose.yml updated to remove version dependency.

* New _includes/people_card.html and _includes/people_horizontal.html created.

* _pages/people.md modified to use the new includes.

* _sass/_base.scss updated to style the new extra_info field.

The changes resulted in flat card with no hyperlinks and the option to add extra information.

### Usage

* Add or modify the extra_info field in a person’s markdown file to include additional info or links.

Example (commented out in the file):
```
extra_info: >
  <ul>
    <li><a href="https://jiefengsun.github.io/">Personal Website</a></li>
    <li>Info 2</li>
  </ul>
```
When uncommented, it will display under the person’s description. Links are styled separately from the main description.